### PR TITLE
Fix git email detection to cover all work envtypes

### DIFF
--- a/git-config.sh
+++ b/git-config.sh
@@ -7,7 +7,7 @@ source "$SELF_PATH/bash_common.sh"
 
 echo "git config"
 
-if is_maxmind || [[ ${DOTFILES_ENVTYPE:-} == 'devcontainer-work' ]]; then
+if is_maxmind || [[ ${DOTFILES_ENVTYPE:-} =~ work ]]; then
   git config --global user.email "kphair@maxmind.com"
 else
   git config --global user.email "phair.kevin@gmail.com"


### PR DESCRIPTION
The devcontainer-work check added in 6f99810 missed local-work and remote-work. Use =~ work to match all three variants via the marker file.

Co-Authored-By: Claude Sonnet 4.6